### PR TITLE
use 'complete' callback instead of 'success'

### DIFF
--- a/jquery.queryloader2.js
+++ b/jquery.queryloader2.js
@@ -110,7 +110,7 @@
             $.ajax({
                 url: qLimages[i],
                 type: 'HEAD',
-                success: function(data) {
+                complete: function(data) {
                     if(!qLdestroyed){
                         qLimageCounter++;
                         addImageForPreload(this['url']);


### PR DESCRIPTION
I was trying to preload my images from Dropbox when server give 304 response, this response didn't fall on success callback so the loading bar never finished and my page can't be displayed.

This commit change 'success' callback to 'complete' so page will be displayed whatever response from the server.
