### PR TITLE
Bug squash: the loader hangs, sometimes cleared on refresh

### DIFF
--- a/jquery.queryloader2.js
+++ b/jquery.queryloader2.js
@@ -76,7 +76,7 @@
         };
 
         base.addImageForPreload = function(url) {
-            var image = $("<img />").attr("src", url);
+            var image = $("img").attr("src", url);
             //binding load before the DOM adding
             base.bindLoadEvent(image);
             image.appendTo(base.qLimageContainer);


### PR DESCRIPTION
http://api.jquery.com/element-selector/
You can target elements by their tag alone, < tag /> way of targeting will fail when loading images with non-xhtml strict (ie. that do not have closing slash) tags.
