### PR TITLE
fixed url when element has no src attr

### DIFF
--- a/src/ImagePreloader/index.js
+++ b/src/ImagePreloader/index.js
@@ -89,9 +89,9 @@ var ImagePreloader = {
       //if object has background image
       url = (style.backgroundImage || element.style.backgroundImage);
       type = 'background';
-    } else if (typeof element.getAttribute('src') !== 'undefined' && element.nodeName.toLowerCase() === 'img') {
+    } else if (element.nodeName.toLowerCase() === 'img') {
       //if is img and has src
-      url = element.getAttribute('src') || '';
+      url = element.src;
     }
 
     return {

--- a/src/ImagePreloader/index.js
+++ b/src/ImagePreloader/index.js
@@ -91,7 +91,7 @@ var ImagePreloader = {
       type = 'background';
     } else if (typeof element.getAttribute('src') !== 'undefined' && element.nodeName.toLowerCase() === 'img') {
       //if is img and has src
-      url = element.getAttribute('src');
+      url = element.getAttribute('src') || '';
     }
 
     return {

--- a/test/tests.js
+++ b/test/tests.js
@@ -319,6 +319,9 @@ describe('ImagePreloader', function() {
     img5.style.background = 'url(fakeimg5.png)';
     fakeImagesContainer.appendChild(img5);
 
+    var img6 = document.createElement('img');
+    fakeImagesContainer.appendChild(img6);
+
     it('should get all images within the given element', function() {
       var images = ip.getImageSrcs(fakeImagesContainer);
 


### PR DESCRIPTION
for example: when use angular, there is a ng-src instead of src before loading; If not handle this, it will cause a js error.